### PR TITLE
This will fix two things after installing puppetmaster

### DIFF
--- a/puppet3/PKGBUILD
+++ b/puppet3/PKGBUILD
@@ -76,6 +76,10 @@ package() {
   install -d $pkgdir/etc/{puppet,rc.d}
   install -m 644 $srcdir/puppet.conf $pkgdir/etc/puppet/puppet.conf
   install -m 644 $srcdir/fileserver.conf $pkgdir/etc/puppet/fileserver.conf
+  
+  # Setup tmpfiles.d config
+  install -d $pkgdir/etc/tmpfiles.d
+  echo "D /var/run/puppet 0755 puppet puppet -" > $pkgdir/etc/tmpfiles.d/puppet.conf
 
   # Configuration for hiera / symlink is there to use hiera within puppet.
   install -m 644 $srcdir/hiera.yaml $pkgdir/etc/

--- a/puppet3/puppet.conf
+++ b/puppet3/puppet.conf
@@ -1,7 +1,7 @@
 [main]
     # The Puppet var directory
-    # The default value is '/var/run/puppet'
-    vardir = /var/run/puppet
+    # The default value is '/var/lib/puppet'
+    vardir = /var/lib/puppet
 
     # The Puppet log directory.
     # The default value is '$vardir/log'.


### PR DESCRIPTION
first vardir was set wrong to tmpfs /var/run it should be /var/lib/puppet
second no tmpfiles.d config for puppet now /var/run/puppet directory will
be present at boot with a systemd config

modified:   PKGBUILD
modified:   puppet.conf
