### PR TITLE
Updated puppet version 3.1.1 Security Release

### DIFF
--- a/puppet/PKGBUILD
+++ b/puppet/PKGBUILD
@@ -10,12 +10,12 @@
 # RC style, reserved for later use
 #pkgname=puppet
 #_rc=2
-#_pkgver=3.1.0
+#_pkgver=3.1.1
 #pkgver=${_pkgver}_rc${_rc}
 
 pkgname=puppet
 _gemname=puppet
-pkgver=3.1.0
+pkgver=3.1.1
 pkgrel=0
 pkgdesc="A system for automating system administration tasks."
 arch=("any")
@@ -32,7 +32,7 @@ source=(
         "http://gems.rubyforge.org/gems/${_gemname}-${pkgver}.gem"
         "puppet"
         "puppetmaster")
-md5sums=('1e9fc8e751e9c3728411c7ba46030071'
+md5sums=('c2192ca1412cefa72e5c9c1226eabff1'
          '59dbf39e251bc4877e7604a5876c642d'
          '4c507c580cb28d7a5adc9ea6b3626657')
 noextract=(${_gemname}-${pkgver}.gem)


### PR DESCRIPTION
Puppet 3.1.1 addresses several security:
vulnerabilities discovered in the 3.x line of Puppet. These
vulnerabilities have been assigned Mitre CVE numbers CVE-2013-1640,
CVE-2013-1652, CVE-2013-1653, CVE-2013-1654, CVE-2013-1655 and
CVE-2013-2275.

All users of Puppet 3.1.0 and earlier are strongly encouraged to
upgrade to 3.1.1.
